### PR TITLE
#24 Background submission with Axios and queue

### DIFF
--- a/lib/base_logger.js
+++ b/lib/base_logger.js
@@ -1,11 +1,12 @@
 // © 2016-2021 Resurface Labs Inc.
 
-const http = require('http');
-const https = require('https');
 const os = require('os');
-const urls = require('url');
 const usage_loggers = require('./usage_loggers');
 const zlib = require('zlib');
+const axios = require('axios');
+const async = require('async');
+
+const DEFAULT_MAX_TRANSMIT = 128;
 
 /**
  * Basic usage logger to embed or extend.
@@ -19,8 +20,6 @@ class BaseLogger {
         this._agent = agent;
         this._host = BaseLogger.host_lookup();
         this._queue = null;
-        this._skip_compression = false;
-        this._skip_submission = false;
         this._url = null;
         this._version = BaseLogger.version_lookup();
 
@@ -31,9 +30,14 @@ class BaseLogger {
         const queue_exists = (typeof queue === 'object') && Array.isArray(queue);
         const url = (typeof options === 'string') ? options : options['url'];
         const url_exists = (typeof url === 'string');
+        const skip_compression = options['skip_compression'];
+        const skip_submission = options['skip_submission'];
+        const max_transmit = options['max_transmit'];
 
         // set options in priority order
         this._enabled = !enabled_exists || (enabled_exists && enabled === true);
+        this._skip_compression = (typeof skip_compression === 'boolean') ? skip_compression : false;
+        this._skip_submission = (typeof skip_submission === 'boolean') ? skip_submission : false;
         if (queue_exists) {
             this._queue = queue;
         } else if (url_exists) {
@@ -52,26 +56,27 @@ class BaseLogger {
         // parse and cache url properties
         if (this._url != null) {
             try {
-                const target = urls.parse(this._url);
-                this._url_library = target.protocol === 'https' ? https : http;
                 this._url_options = {
-                    host: target.host.split(':')[0],
-                    port: target.port,
-                    path: target.path,
-                    method: 'POST',
+                    url: this._url,
+                    method: 'post',
+                    // timeout: ,
                     headers: {
                         'Content-Encoding': this._skip_compression ? 'identity' : 'deflated',
                         'Content-Type': 'application/json; charset=UTF-8',
                         'User-Agent': `Resurface/${this.version} (${this._agent})`
                     }
-                };
+                }
             } catch (e) {
                 this._url = null;
-                this._url_library = null;
                 this._url_options = null;
                 this._enabled = false;
             }
         }
+
+        // create transmission queue
+        this._max_transmit = (typeof max_transmit === 'number') ? max_transmit : DEFAULT_MAX_TRANSMIT;
+        this._transmit_count = 0;
+        this._transmit_queue = async.queue(this.hermes.bind(this), 1);
 
         // finalize internal properties
         this._enableable = (this._queue !== null) || (this._url !== null);
@@ -85,9 +90,9 @@ class BaseLogger {
         Object.defineProperty(this, '_submit_failures', {configurable: false, writable: false});
         Object.defineProperty(this, '_submit_successes', {configurable: false, writable: false});
         Object.defineProperty(this, '_url', {configurable: false, writable: false});
-        Object.defineProperty(this, '_url_library', {configurable: false, writable: false});
         Object.defineProperty(this, '_url_options', {configurable: false, writable: false});
         Object.defineProperty(this, '_version', {configurable: false, writable: false});
+        Object.defineProperty(this, '_max_transmit', {configurable: false, writable: false});
     }
 
     /**
@@ -161,6 +166,7 @@ class BaseLogger {
      */
     set skip_compression(value) {
         this._skip_compression = value;
+        this._url_options.headers['Content-Encoding'] = value ? 'identity' : 'deflated';
     }
 
     /**
@@ -190,33 +196,49 @@ class BaseLogger {
         } else {
             return new Promise((resolve, reject) => {
                 try {
-                    const request = this._url_library.request(this._url_options, (response) => {
-                        if (response.statusCode === 204) {
-                            Atomics.add(this._submit_successes, 0, 1);
-                            resolve(true);
-                        } else {
-                            Atomics.add(this._submit_failures, 0, 1);
-                            resolve(true);
-                        }
-                    });
-                    request.on('error', () => {
-                        Atomics.add(this._submit_failures, 0, 1);
-                        resolve(true);
-                    });
                     if (this._skip_compression) {
-                        request.write(msg);
-                        request.end();
-                    } else {
-                        zlib.deflate(msg, function (err, buffer) {
-                            request.write(buffer);
-                            request.end();
+                        this._transmit_queue.push(msg, (err, increase) => {
+                            increase? this._transmit_count++ : this._transmit_count--;
                         });
+                    } else {
+                        zlib.deflate(msg, (err, buffer) => this._transmit_queue.push(buffer, (err, increase) => {
+                            increase? this._transmit_count++ : this._transmit_count--;
+                        }));
                     }
                 } catch (e) {
                     Atomics.add(this._submit_failures, 0, 1);
+                } finally {
                     resolve(true);
                 }
             });
+        }
+    }
+
+    hermes(msg, callback) {
+        if (this._transmit_count < this._max_transmit) {
+            axios.post(this.url, msg, this._url_options)
+            .then((response) => {
+                if (response.status === 204) {
+                    Atomics.add(this._submit_successes, 0, 1);
+                } else {
+                    Atomics.add(this._submit_failures, 0, 1);
+                }
+                this.transmit_count--;
+            })
+            .catch(() => Atomics.add(this._submit_failures, 0, 1));
+            callback(null, true);
+        } else {
+            axios.post(this.url, msg, this._url_options)
+            .then((response) => {
+                if (response.status === 204) {
+                    Atomics.add(this._submit_successes, 0, 1);
+                } else {
+                    Atomics.add(this._submit_failures, 0, 1);
+                }
+                callback(null, false);
+            })
+            .catch(() => Atomics.add(this._submit_failures, 0, 1));
+            this.transmit_count++;
         }
     }
 

--- a/lib/base_logger.js
+++ b/lib/base_logger.js
@@ -4,7 +4,6 @@ const os = require('os');
 const usage_loggers = require('./usage_loggers');
 const zlib = require('zlib');
 const axios = require('axios');
-const async = require('async');
 
 const DEFAULT_MAX_TRANSMIT = 128;
 
@@ -75,8 +74,7 @@ class BaseLogger {
 
         // create transmission queue
         this._max_transmit = (typeof max_transmit === 'number') ? max_transmit : DEFAULT_MAX_TRANSMIT;
-        this._transmit_count = 0;
-        this._transmit_queue = async.queue(this.hermes.bind(this), 1);
+        this._transmit_queue = [];
 
         // finalize internal properties
         this._enableable = (this._queue !== null) || (this._url !== null);
@@ -195,51 +193,38 @@ class BaseLogger {
             return new Promise((resolve, reject) => resolve(true));
         } else {
             return new Promise((resolve, reject) => {
-                try {
-                    if (this._skip_compression) {
-                        this._transmit_queue.push(msg, (err, increase) => {
-                            increase? this._transmit_count++ : this._transmit_count--;
-                        });
-                    } else {
-                        zlib.deflate(msg, (err, buffer) => this._transmit_queue.push(buffer, (err, increase) => {
-                            increase? this._transmit_count++ : this._transmit_count--;
-                        }));
-                    }
-                } catch (e) {
-                    Atomics.add(this._submit_failures, 0, 1);
-                } finally {
-                    resolve(true);
+                if (this._skip_compression) {
+                    this.hermes(msg).then(resolve(true));
+                } else {
+                    zlib.deflate(msg, (err, buffer) => {
+                        if (err != null) {
+                            Atomics.add(this._submit_failures, 0, 1);
+                            reject(true);
+                        } else {
+                            this.hermes(buffer).then(resolve(true));
+                        }
+                    });
                 }
             });
         }
     }
 
-    hermes(msg, callback) {
-        if (this._transmit_count < this._max_transmit) {
-            axios.post(this.url, msg, this._url_options)
-            .then((response) => {
-                if (response.status === 204) {
-                    Atomics.add(this._submit_successes, 0, 1);
-                } else {
-                    Atomics.add(this._submit_failures, 0, 1);
-                }
-                this.transmit_count--;
-            })
-            .catch(() => Atomics.add(this._submit_failures, 0, 1));
-            callback(null, true);
-        } else {
-            axios.post(this.url, msg, this._url_options)
-            .then((response) => {
-                if (response.status === 204) {
-                    Atomics.add(this._submit_successes, 0, 1);
-                } else {
-                    Atomics.add(this._submit_failures, 0, 1);
-                }
-                callback(null, false);
-            })
-            .catch(() => Atomics.add(this._submit_failures, 0, 1));
-            this.transmit_count++;
-        }
+    /**
+     * Creates promise to submit JSON message to intended destination.
+     */
+    async hermes(message) {
+        while (this._transmit_queue.length >= this._max_transmit) await Promise.race(this._transmit_queue);
+        let p = axios.post(this.url, message, this._url_options)
+        .then((response) => {
+            if (response.status === 204) {
+                Atomics.add(this._submit_successes, 0, 1);
+            } else {
+                Atomics.add(this._submit_failures, 0, 1);
+            }
+            this._transmit_queue.splice(this._transmit_queue.indexOf(p), 1);
+        })
+        .catch(() => Atomics.add(this._submit_failures, 0, 1));
+        this._transmit_queue.push(p);
     }
 
     /**


### PR DESCRIPTION
Http/https requests are now made using Axios. Both options `skip_compression` and `skip_submission` are now read in the constructor, and the `_url_options` structure is recomputed inside `skip_compression`'s setter. The Async package doesn't offer a bounded queue; `async.queue` can be configured to limit the concurrency (# of "parallel" workers), but not its depth. This functionality is achieved by counting the number of submissions, using a callback to change the value accordingly. The "blocking" behavior is achieved by taking advantage of the Promise-based nature of Axios.