### PR TITLE
#28 Koa middleware

### DIFF
--- a/lib/all.js
+++ b/lib/all.js
@@ -4,6 +4,7 @@ module.exports = {
     BaseLogger: require('./base_logger'),
     HttpLogger: require('./http_logger'),
     HttpLoggerForExpress: require('./http_logger_for_express'),
+    HttpLoggerForKoa: require('./http_logger_for_koa'),
     HttpMessage: require('./http_message'),
     HttpRequestImpl: require('./http_request_impl'),
     HttpResponseImpl: require('./http_response_impl'),

--- a/lib/http_logger_for_koa.js
+++ b/lib/http_logger_for_koa.js
@@ -1,0 +1,73 @@
+// © 2016-2021 Resurface Labs Inc.
+
+const HttpLogger = require('./http_logger');
+const HttpMessage = require('./http_message');
+
+/**
+ * Koa middleware for HTTP usage logging.
+ */
+class HttpLoggerForKoa {
+
+    /**
+     * Add new logger to the specified Koa app.
+     */
+    static add(app, options = {}) {
+        app.use(this.build(options));
+    }
+
+    /**
+     * Builds and initializes logger as Express middleware.
+     */
+    static build(options = {}) {
+        const logger = new HttpLoggerForKoa(options);
+        return logger.handle.bind(logger);
+    }
+
+    /**
+     * Initialize a new logger with specified options.
+     */
+    constructor(options = {}) {
+        this._logger = new HttpLogger(options);
+        Object.defineProperty(this, '_logger', {configurable: false, writable: false});
+    }
+
+    /**
+     * Returns wrapped logger instance.
+     */
+    get logger() {
+        return this._logger;
+    }
+
+    /**
+     * Called when request/response is passed through middleware.
+     */
+    async handle(ctx, next) {
+		ctx.started = this._logger.hrmillis;
+        if (this._logger.enabled) {
+            this.log(ctx);
+		}
+		await next();
+    };
+
+    /**
+     * Logs the request/response from within middleware.
+     */
+    log(ctx) {
+        const logger = this._logger;
+
+        // declare event handler
+        function afterResponse() {
+            ctx.res.removeListener('finish', afterResponse);
+            ctx.response.statusCode = ctx.status;
+            const now = Date.now().toString();
+            const interval = (logger.hrmillis - ctx.started).toString();
+            return HttpMessage.send(logger, ctx.request, ctx.response, ctx.body, undefined, now, interval);
+        }
+
+        // register event handler
+        ctx.res.on('finish', afterResponse);
+    }
+
+}
+
+module.exports = HttpLoggerForKoa;

--- a/lib/http_message.js
+++ b/lib/http_message.js
@@ -26,7 +26,7 @@ class HttpMessage {
                     for (let d0 in ssn)
                         if (d0.match(r.param1)) {
                             const d1 = ssn[d0];
-                            message.push([`session_field:${d0}`, (typeof d1 === 'string') ? d1 : util.inspect(d1)]);
+                            message.push([`session_field:${d0.toLowerCase()}`, (typeof d1 === 'string') ? d1 : util.inspect(d1)]);
                         }
         }
 

--- a/lib/http_message.js
+++ b/lib/http_message.js
@@ -74,7 +74,7 @@ class HttpMessage {
         const body = request.body;
         if (body != undefined) {
             for (const key in body) {
-                if (body.hasOwnProperty(key)) {
+                if (Object.prototype.hasOwnProperty.call(body, key)) {
                     message.push([`request_param:${key.toLowerCase()}`, body[key]]);
                 }
             }
@@ -82,7 +82,7 @@ class HttpMessage {
         const query = request.query;
         if (query != undefined) {
             for (const key in query) {
-                if (query.hasOwnProperty(key)) {
+                if (Object.prototype.hasOwnProperty.call(query, key)) {
                     message.push([`request_param:${key.toLowerCase()}`, query[key]]);
                 }
             }

--- a/lib/http_rules.js
+++ b/lib/http_rules.js
@@ -168,7 +168,7 @@ class HttpRules {
 
         // parse all rules
         let prs = [];
-        for (let rule of this.text.split("\n")) {
+        for (let rule of this.text.split(/[\r\n]/)) {
             const parsed = HttpRules.parseRule(rule);
             if (parsed !== null) prs.push(parsed);
         }


### PR DESCRIPTION
Also replaced `body.hasOwnProperty(key)` with `Object.prototype.hasOwnProperty.call(body, key)` because Koa's objects are based on `null` directly (and because of this, they don't inherit from `Object.protoype`). Also, this way might be [safer](https://stackoverflow.com/questions/12017693/why-use-object-prototype-hasownproperty-callmyobj-prop-instead-of-myobj-hasow)